### PR TITLE
Fix Python Syntax Error caused by missing comma

### DIFF
--- a/metrics/compute_metrics.py
+++ b/metrics/compute_metrics.py
@@ -223,8 +223,8 @@ def main():
             args.dataset, 
             args.output_path, 
             scales_img, 
-            scales_txt
-            steps = args.steps
+            scales_txt,
+            steps = args.steps,
             )
     
     plot_metrics(metrics_file, args.output_path)


### PR DESCRIPTION
% `flake8 . --count --select=E9,F63,F7,F82,Y --show-source --statistics`
```
./metrics/compute_metrics.py:226:14: E999 SyntaxError: invalid syntax. Perhaps you forgot a comma?
            scales_txt
             ^
```