### PR TITLE
add instructions for easy installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,17 @@ python edit_app.py
 ![Edit app](https://github.com/timothybrooks/instruct-pix2pix/blob/main/imgs/edit_app.jpg?raw=true)
 
 _(For advice on how to get the best results by tuning parameters, see the [Tips](https://github.com/timothybrooks/instruct-pix2pix#tips) section)._
+### Quickstart via [Imaginairy](https://github.com/brycedrennan/imaginAIry#-edit-images-with-instructions-alone-by-instructpix2pix)
+**(alternative installation method)**
+```bash
+pip install imaginairy --upgrade
+# edit a single image and make a gif showing the difference
+aimg edit any-image.jpg --gif "turn him into a cyborg" 
+# make a bunch of pre-determined edits and turn them into a gif
+aimg edit --gif --surprise-me pearl-earring.jpg 
+```
+<img src="https://raw.githubusercontent.com/brycedrennan/imaginAIry/7c05c3aae2740278978c5e84962b826e58201bac/assets/girl_with_a_pearl_earring_suprise.gif" height="512">
+
 
 ## Setup
 


### PR DESCRIPTION
Amazing work! I integrated this into my project and thought it might help people wanting to try it out on their computers.

admittedly self-serving to include this here but I do think it has the following advantages:
 - easier to install that this repo (just pip install and done)
 - easier to use than the command line tool of this repo and diffusers
 - runs on Mac (m1 and intel), linux, and windows
 - only needs at most 11 GB GPU ram (that's what I'm running it on).
 - comes with all the additional features of imaginairy
 
 See additional demos here:
 https://github.com/brycedrennan/imaginAIry#-edit-images-with-instructions-alone-by-instructpix2pix
