### PR TITLE
Making gradio private by default, and adding --public argument

### DIFF
--- a/edit_app.py
+++ b/edit_app.py
@@ -103,6 +103,7 @@ def main():
     parser.add_argument("--config", default="configs/generate.yaml", type=str)
     parser.add_argument("--ckpt", default="checkpoints/instruct-pix2pix-00-22000.ckpt", type=str)
     parser.add_argument("--vae-ckpt", default=None, type=str)
+    parser.add_argument("--public", action='store_true')
     args = parser.parse_args()
 
     config = OmegaConf.load(args.config)
@@ -261,7 +262,10 @@ def main():
         )
 
     demo.queue(concurrency_count=1)
-    demo.launch(share=True)
+    if args.public:
+        demo.launch(share=True)
+    else:
+        demo.launch(share=False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This may be more of a matter of opinion, so feel free to reject this if it doesn't fit.

Basically, I noticed that when I run edit_app.py gradio automatically runs a public link accessible from the inernet, and the only way to turn it off was to edit the code. I thought this could potentially be insecure to have it as the default behavior, since there are a lot of people using this who may not understand the implications.

I made the default behavior of edit_app.py gradio to be a private link, and I added a --public arg in case anyone wants to make their app accessible from anywhere.

Thank you.